### PR TITLE
Scheduled timezone bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .DS_Store
 /nbproject/private/
 node_modules
+.vscode

--- a/src/scheduled.service.js
+++ b/src/scheduled.service.js
@@ -13,8 +13,6 @@ plugin.service('wgnScheduledWebhook', ['wgnWebhookCommon', function (webhookComm
 		var defaults = {
 			frequency: 'daily',
 			description: 'Scheduled webhook for wgn',
-			start: moment().format('YYYY-MM-DD[T]HH:mm:ss'),
-			timezone: 'UTC',
 			isActive: false,
 			url: ''
 		};

--- a/src/scheduled.service.js
+++ b/src/scheduled.service.js
@@ -13,8 +13,8 @@ plugin.service('wgnScheduledWebhook', ['wgnWebhookCommon', function (webhookComm
 		var defaults = {
 			frequency: 'daily',
 			description: 'Scheduled webhook for wgn',
-			start: new Date(),
-			timezone: 'America/New_York',
+			start: moment().format('YYYY-MM-DD[T]HH:mm:ss'),
+			timezone: 'UTC',
 			isActive: false,
 			url: ''
 		};

--- a/src/scheduled.service.js
+++ b/src/scheduled.service.js
@@ -20,7 +20,7 @@ plugin.service('wgnScheduledWebhook', ['wgnWebhookCommon', function (webhookComm
 		};
 
 		if ('start' in options && options.start) {
-			defaults.start = moment(options.start).format('YYYY-MM-DD[T]HH:mm:ss');
+			options.start = moment(options.start).format('YYYY-MM-DD[T]HH:mm:ss');
 		}
 
 		return webhookCommon.create(defaults, options, true);


### PR DESCRIPTION
This should be the short-term conclusion of the extra-4-hour bug that was plaguing me the last few days. By simply defaulting to UTC as the timezone, that problem never re-surfaced, and I was able to programmatically create and update my scheduled webhooks to run at exact to-the-customized-minute intervals using the existing webhook APIs.

I think the documentation should be updated regarding the default timezone (it currently says that it defaults to New_York/America), but I'm not sure exactly where to go with that. @alexweber @wdmny I would like to get your thoughts on that.